### PR TITLE
Issue #10: Infinite loop in color tag handler

### DIFF
--- a/utchat/client/chathandlers/colorconstants.lua
+++ b/utchat/client/chathandlers/colorconstants.lua
@@ -10,17 +10,18 @@ Events:Subscribe("ModulesLoad", function( )
 		local startindex, color = utxt.text:match("()%(([%a%s]+)%).+")
 		do
 			if not startindex or not color then goto final end
-			
+
 			local function tchelper(first, rest)
 			  return first:upper()..rest:lower()
 			end
-			
-			local fcolor = color:gsub("(%a)([%w_']*)", tchelper):gsub("(.-)%s(.-)","%1%2")			
-			
+
+			local fcolor = color:gsub("(%a)([%w_']*)", tchelper):gsub("(.-)%s(.-)","%1%2")
+
+			utxt:RemoveText(startindex, startindex+#color+1)
 			if Color[fcolor] then
-				utxt:RemoveText(startindex, startindex+#color+1)
 				utxt:Format("color", startindex, #utxt.text, Color[fcolor])
 			end
+			
 			goto redo
 		end
 		::final::


### PR DESCRIPTION
Fix for Issue #10

Caused by an infinite loop in the color tag handler when a color tag is used with an invalid or non-existent color.

Under review to confirm fix before merge